### PR TITLE
Add support for static method callback format

### DIFF
--- a/command.php
+++ b/command.php
@@ -21,7 +21,10 @@ $hook_command = function( $args, $assoc_args ) {
 		foreach( $callbacks as $callback ) {
 			if ( is_array( $callback['function'] ) && is_object( $callback['function'][0] ) ) {
 				$callback['function'] = get_class( $callback['function'][0] ) . '->' . $callback['function'][1];
+			} elseif ( is_array( $callback['function'] ) && method_exists( $callback['function'][0], $callback['function'][1] ) ) {
+				$callback['function'] = $callback['function'][0] . '::' . $callback['function'][1];
 			}
+
 			$callbacks_output[] = array(
 				'function'        => $callback['function'],
 				'priority'        => $priority,


### PR DESCRIPTION
This PR changes static method callbacks to be formatted similar to how instance method callbacks are already displayed using their respective operators. 

Instance `->`
Static `::`

Cool command btw!  :+1: 
